### PR TITLE
Logfile config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ These options can be used when starting the `postfix_exporter`
 | `--web.telemetry-path`   | Path under which to expose metrics                   | `/metrics`                        |
 | `--postfix.showq_path`   | Path at which Postfix places its showq socket        | `/var/spool/postfix/public/showq` |
 | `--postfix.logfile_path` | Path where Postfix writes log entries                | `/var/log/mail.log`               |
+| `--postfix.logfile_must_exist` | Fail if the log file doesn't exist.            | `true`                            |
+| `--postfix.logfile_debug` | Enable debug logging for the log file.              | `false`                           |
 | `--log.unsupported`      | Log all unsupported lines                            | `false`                           |
 | `--docker.enable`        | Read from the Docker logs instead of a file          | `false`                           |
 | `--docker.container.id`  | The container to read Docker logs from               | `postfix`                         |

--- a/logsource_file.go
+++ b/logsource_file.go
@@ -9,20 +9,22 @@ import (
 	"github.com/nxadm/tail"
 )
 
+var defaultConfig = tail.Config{
+	ReOpen:    true,                               // reopen the file if it's rotated
+	MustExist: true,                               // fail immediately if the file is missing or has incorrect permissions
+	Follow:    true,                               // run in follow mode
+	Location:  &tail.SeekInfo{Whence: io.SeekEnd}, // seek to end of file
+	Logger:    tail.DiscardingLogger,
+	}
+
 // A FileLogSource can read lines from a file.
 type FileLogSource struct {
 	tailer *tail.Tail
 }
 
 // NewFileLogSource creates a new log source, tailing the given file.
-func NewFileLogSource(path string) (*FileLogSource, error) {
-	tailer, err := tail.TailFile(path, tail.Config{
-		ReOpen:    true,                               // reopen the file if it's rotated
-		MustExist: true,                               // fail immediately if the file is missing or has incorrect permissions
-		Follow:    true,                               // run in follow mode
-		Location:  &tail.SeekInfo{Whence: io.SeekEnd}, // seek to end of file
-		Logger:    tail.DiscardingLogger,
-	})
+func NewFileLogSource(path string, config tail.Config) (*FileLogSource, error) {
+	tailer, err := tail.TailFile(path, config)
 	if err != nil {
 		return nil, err
 	}
@@ -62,11 +64,25 @@ func (s *FileLogSource) Read(ctx context.Context) (string, error) {
 // Because this factory is enabled by default, it must always be
 // registered last.
 type fileLogSourceFactory struct {
-	path string
+	path      string
+	mustExist bool
+	debug     bool
 }
 
 func (f *fileLogSourceFactory) Init(app *kingpin.Application) {
 	app.Flag("postfix.logfile_path", "Path where Postfix writes log entries.").Default("/var/log/mail.log").StringVar(&f.path)
+	app.Flag("postfix.logfile_must_exist", "Fail if the log file doesn't exist.").Default("true").BoolVar(&f.mustExist)
+	app.Flag("postfix.logfile_debug", "Enable debug logging for the log file.").Default("false").BoolVar(&f.debug)
+}
+
+// config returns a tail.Config configured from the factory's fields.
+func (f fileLogSourceFactory) config() tail.Config {
+	conf := defaultConfig
+	conf.MustExist = f.mustExist
+	if f.debug {
+		conf.Logger = tail.DefaultLogger
+	}
+	return conf
 }
 
 func (f *fileLogSourceFactory) New(ctx context.Context) (LogSourceCloser, error) {
@@ -74,5 +90,5 @@ func (f *fileLogSourceFactory) New(ctx context.Context) (LogSourceCloser, error)
 		return nil, nil
 	}
 	log.Printf("Reading log events from %s", f.path)
-	return NewFileLogSource(f.path)
+	return NewFileLogSource(f.path, f.config())
 }

--- a/logsource_file_test.go
+++ b/logsource_file_test.go
@@ -18,7 +18,7 @@ func TestFileLogSource_Path(t *testing.T) {
 	}
 	defer close()
 
-	src, err := NewFileLogSource(path)
+	src, err := NewFileLogSource(path, defaultConfig)
 	if err != nil {
 		t.Fatalf("NewFileLogSource failed: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestFileLogSource_Read(t *testing.T) {
 	}
 	defer close()
 
-	src, err := NewFileLogSource(path)
+	src, err := NewFileLogSource(path, defaultConfig)
 	if err != nil {
 		t.Fatalf("NewFileLogSource failed: %v", err)
 	}


### PR DESCRIPTION
In some use cases, it may be useful to change the hardcoded `tail.Config` settings. For instance, when running `postfix_exporter` as a sidecar container the log file may not yet be created by the main `postfix` container upon starting `postfix_exporter` and as a result we needed to have `MustExist` set to `false`. It is also useful to keep logs from the `tail` module for debugging purposes.

This PR introduces the ability to configure some of the `tail.Config` settings by exposing them as command line flag to `fileLogSourceFactory`.