### PR TITLE
prevent empty sasl_method and remove , in method name on postfix_smtpd_messages_processed_total

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -404,9 +404,9 @@ func (e *PostfixExporter) CollectFromLogLine(line string) {
 			} else if smtpdLostConnectionMatches := smtpdLostConnectionLine.FindStringSubmatch(remainder); smtpdLostConnectionMatches != nil {
 				e.smtpdLostConnections.WithLabelValues(smtpdLostConnectionMatches[1]).Inc()
 			} else if smtpdProcessesSASLMatches := smtpdProcessesSASLLine.FindStringSubmatch(remainder); smtpdProcessesSASLMatches != nil {
-				e.smtpdProcesses.WithLabelValues(smtpdProcessesSASLMatches[1]).Inc()
+				e.smtpdProcesses.WithLabelValues(strings.Replace(smtpdProcessesSASLMatches[1],",","",-1)).Inc()
 			} else if strings.Contains(remainder, ": client=") {
-				e.smtpdProcesses.WithLabelValues("").Inc()
+				e.smtpdProcesses.WithLabelValues("NONE").Inc()
 			} else if smtpdRejectsMatches := smtpdRejectsLine.FindStringSubmatch(remainder); smtpdRejectsMatches != nil {
 				e.smtpdRejects.WithLabelValues(smtpdRejectsMatches[1]).Inc()
 			} else if smtpdSASLAuthenticationFailuresLine.MatchString(remainder) {


### PR DESCRIPTION
Hi,
this is pr is to prevent empty sasl_method and remove "," in method name on postfix_smtpd_messages_processed_total metric.

Before:

`postfix_smtpd_messages_processed_total{sasl_method=""} 4
postfix_smtpd_messages_processed_total{sasl_method="PLAIN,"} 5943`

after

`postfix_smtpd_messages_processed_total{sasl_method="NONE"} 4
postfix_smtpd_messages_processed_total{sasl_method="PLAIN"} 5943`

BR,
bluelineXY