### PR TITLE
Reset showq histograms before every collect

### DIFF
--- a/showq/showq.go
+++ b/showq/showq.go
@@ -109,7 +109,6 @@ func (s *Showq) collectTextualShowqFromScanner(file io.Reader) error {
 	}
 	for q, count := range queueSizes {
 		s.queueMessageGauge.WithLabelValues(q).Set(count)
-		s.knownQueues[q] = struct{}{}
 	}
 	return scanner.Err()
 }
@@ -194,7 +193,6 @@ func (s *Showq) collectBinaryShowqFromScanner(file io.Reader) error {
 
 	for q, count := range queueSizes {
 		s.queueMessageGauge.WithLabelValues(q).Set(count)
-		s.knownQueues[q] = struct{}{}
 	}
 	for q := range s.knownQueues {
 		if _, seen := queueSizes[q]; !seen {

--- a/showq/showq.go
+++ b/showq/showq.go
@@ -49,10 +49,9 @@ func (s *Showq) collectTextualShowqFromScanner(file io.Reader) error {
 	// Remove metrics from size and age histograms and re-initialize them. HistogramVec
 	// is intended to capture data streams. Showq however always returns all emails
 	// currently queued, therefore we need to reset the histograms before every collect.
+	s.sizeHistogram.Reset()
+	s.ageHistogram.Reset()
 	for _, q := range []string{"active", "hold", "other"} {
-		// Delete histogram metrics
-		s.sizeHistogram.DeleteLabelValues(q)
-		s.ageHistogram.DeleteLabelValues(q)
 		// Re-initialize histograms to ensure all labels are present.
 		s.sizeHistogram.WithLabelValues(q)
 		s.ageHistogram.WithLabelValues(q)
@@ -148,10 +147,9 @@ func (s *Showq) collectBinaryShowqFromScanner(file io.Reader) error {
 	// Remove metrics from size and age histograms and re-initialize them. HistogramVec
 	// is intended to capture data streams. Showq however always returns all emails
 	// currently queued, therefore we need to reset the histograms before every collect.
+	s.sizeHistogram.Reset()
+	s.ageHistogram.Reset()
 	for _, q := range []string{"active", "deferred", "hold", "incoming", "maildrop"} {
-		// Delete histogram metrics
-		s.sizeHistogram.DeleteLabelValues(q)
-		s.ageHistogram.DeleteLabelValues(q)
 		// Re-initialize histograms to ensure all labels are present.
 		s.sizeHistogram.WithLabelValues(q)
 		s.ageHistogram.WithLabelValues(q)


### PR DESCRIPTION
This PR addresses the issues described in https://github.com/Hsn723/postfix_exporter/issues/298 and https://github.com/Hsn723/postfix_exporter/issues/299.


## Root cause analysis

Also described in https://github.com/Hsn723/postfix_exporter/issues/298.

`postfix_showq_message_age_seconds_*` and `postfix_showq_message_size_bytes_*` are based on `prometheus.HistogramVec`. `HistogramVec` is intended to monitor data streams and therefore always **adds** new observations (values) to the existing metrics.
The [kumina exporter](https://github.com/kumina/postfix_exporter) avoided this problem by re-initializing `sizeHistogram` and `ageHistogram` on every call of `CollectBinaryShowqFromReader`.

However, the clean up done in commit  [move showq collector into its own module and remove unnecessary mock](https://github.com/Hsn723/postfix_exporter/commit/777a6ea87097a2bd168b9c4e975086f74bea861c#diff-ca2be96297515b14b7831b90d832560c757a812d2bd9f944aabaf9b1439d0527) broke this by moving  `sizeHistogram` and `ageHistogram`  into struct `Showq` (which is otherwise a cleaner approach).

This PR deletes and re-initializes `sizeHistogram` and `ageHistogram` on every call of `collectBinaryShowqFromScanner`, respectively `collectTextualShowqFromScanner` by using `.DeleteLabelValues()` and `.WithLabelValues()` for all label values.