### PR TITLE
Count NOQUEUE lost connections towards _connections_lost_total

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -125,7 +125,7 @@ var (
 	smtpdFCrDNSErrorsLine               = regexp.MustCompile(`^warning: hostname \S+ does not resolve to address `)
 	smtpdProcessesSASLLine              = regexp.MustCompile(`: client=.*, sasl_method=(\S+)`)
 	smtpdRejectsLine                    = regexp.MustCompile(`^NOQUEUE: reject: RCPT from \S+: ([0-9]+) `)
-	smtpdLostConnectionLine             = regexp.MustCompile(`^(NOQUEUE: l|l)ost connection after (\w+) from `)
+	smtpdLostConnectionLine             = regexp.MustCompile(`^(?:NOQUEUE: )?lost connection after (\w+) from `)
 	smtpdSASLAuthenticationFailuresLine = regexp.MustCompile(`^warning: \S+: SASL \S+ authentication failed: `)
 	smtpdTLSLine                        = regexp.MustCompile(`^(\S+) TLS connection established from \S+: (\S+) with cipher (\S+) \((\d+)/(\d+) bits\)`)
 	opendkimSignatureAdded              = regexp.MustCompile(`^[\w\d]+: DKIM-Signature field added \(s=(\w+), d=(.*)\)$`)
@@ -249,7 +249,7 @@ func (e *PostfixExporter) collectSMTPdLog(line, remainder, level string) {
 	} else if smtpdFCrDNSErrorsLine.MatchString(remainder) {
 		e.smtpdFCrDNSErrors.Inc()
 	} else if smtpdLostConnectionMatches := smtpdLostConnectionLine.FindStringSubmatch(remainder); smtpdLostConnectionMatches != nil {
-		e.smtpdLostConnections.WithLabelValues(smtpdLostConnectionMatches[2]).Inc()
+		e.smtpdLostConnections.WithLabelValues(smtpdLostConnectionMatches[1]).Inc()
 	} else if smtpdProcessesSASLMatches := smtpdProcessesSASLLine.FindStringSubmatch(remainder); smtpdProcessesSASLMatches != nil {
 		e.smtpdProcesses.WithLabelValues(strings.ReplaceAll(smtpdProcessesSASLMatches[1], ",", "")).Inc()
 	} else if strings.Contains(remainder, ": client=") {

--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -125,7 +125,7 @@ var (
 	smtpdFCrDNSErrorsLine               = regexp.MustCompile(`^warning: hostname \S+ does not resolve to address `)
 	smtpdProcessesSASLLine              = regexp.MustCompile(`: client=.*, sasl_method=(\S+)`)
 	smtpdRejectsLine                    = regexp.MustCompile(`^NOQUEUE: reject: RCPT from \S+: ([0-9]+) `)
-	smtpdLostConnectionLine             = regexp.MustCompile(`^lost connection after (\w+) from `)
+	smtpdLostConnectionLine             = regexp.MustCompile(`^(NOQUEUE: l|l)ost connection after (\w+) from `)
 	smtpdSASLAuthenticationFailuresLine = regexp.MustCompile(`^warning: \S+: SASL \S+ authentication failed: `)
 	smtpdTLSLine                        = regexp.MustCompile(`^(\S+) TLS connection established from \S+: (\S+) with cipher (\S+) \((\d+)/(\d+) bits\)`)
 	opendkimSignatureAdded              = regexp.MustCompile(`^[\w\d]+: DKIM-Signature field added \(s=(\w+), d=(.*)\)$`)
@@ -249,7 +249,7 @@ func (e *PostfixExporter) collectSMTPdLog(line, remainder, level string) {
 	} else if smtpdFCrDNSErrorsLine.MatchString(remainder) {
 		e.smtpdFCrDNSErrors.Inc()
 	} else if smtpdLostConnectionMatches := smtpdLostConnectionLine.FindStringSubmatch(remainder); smtpdLostConnectionMatches != nil {
-		e.smtpdLostConnections.WithLabelValues(smtpdLostConnectionMatches[1]).Inc()
+		e.smtpdLostConnections.WithLabelValues(smtpdLostConnectionMatches[2]).Inc()
 	} else if smtpdProcessesSASLMatches := smtpdProcessesSASLLine.FindStringSubmatch(remainder); smtpdProcessesSASLMatches != nil {
 		e.smtpdProcesses.WithLabelValues(strings.ReplaceAll(smtpdProcessesSASLMatches[1], ",", "")).Inc()
 	} else if strings.Contains(remainder, ": client=") {


### PR DESCRIPTION
This PR addresses the issue described in https://github.com/Hsn723/postfix_exporter/issues/303.

## Bug description

The metric `postfix_smtpd_connections_lost_total` is based on the regex
```
`^lost connection after (\w+) from `
```
[postfix_exporter.go#L128C59-L128C95](https://github.com/Hsn723/postfix_exporter/blob/master/postfix_exporter.go#L128C59-L128C95)

However, if a connection is lost *before* Postfix assigns a queue ID, the log lines are prefixed with `NOQUEUE:`, e.g.

```
postfix/smtpd[40128]: NOQUEUE: lost connection after CONNECT from unknown[*.*.*.*]
postfix/smtpd[27202]: NOQUEUE: lost connection after EHLO from *****.******.com[*.*.*.*]
postfix/smtpd[26163]: NOQUEUE: lost connection after STARTTLS from unknown[*.*.*.*]
```

These logs are not matched by the current regex and are therefore not counted towards metric `postfix_smtpd_connections_lost_total`. 

## Suggested solution

Change the regex to `^(NOQUEUE: l|l)ost connection after (\w+) from `.

## Optional extension

One could consider adding an additional `noqueue: [true|false]` label to preserve  whether the connection was lost before queuing. However:
- this would double the cardinality of the metric
- it would be a breaking change, as a query for `postfix_smtpd_connections_lost_total` would yield additional results

I would suggest to simply count `NOQUEUE: lost connection` towards `postfix_smtpd_connections_lost_total` without introducing extra labels.
