### PR TITLE
Fix --version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,12 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -w -s
+        -X github.com/prometheus/common/version.Version={{ .Version }}
+        -X github.com/prometheus/common/version.Revision={{ .Commit }}
+        -X github.com/prometheus/common/version.Branch={{ .Branch }}
+        -X github.com/prometheus/common/version.BuildDate={{ .Date }}
   - id: with-docker
     goarch:
       - amd64
@@ -22,6 +28,12 @@ builds:
       - -tags=nosystemd
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -w -s
+        -X github.com/prometheus/common/version.Version={{ .Version }}
+        -X github.com/prometheus/common/version.Revision={{ .Commit }}
+        -X github.com/prometheus/common/version.Branch={{ .Branch }}
+        -X github.com/prometheus/common/version.BuildDate={{ .Date }}
   - id: with-systemd
     goarch:
       - amd64
@@ -34,6 +46,12 @@ builds:
         {{- if eq .Arch "arm64" }}CC=/usr/bin/aarch64-linux-gnu-gcc{{- end }}
     goos:
       - linux
+    ldflags:
+      - -w -s
+        -X github.com/prometheus/common/version.Version={{ .Version }}
+        -X github.com/prometheus/common/version.Revision={{ .Commit }}
+        -X github.com/prometheus/common/version.Branch={{ .Branch }}
+        -X github.com/prometheus/common/version.BuildDate={{ .Date }}
   - id: aio
     goos:
       - linux
@@ -44,6 +62,12 @@ builds:
       - CGO_ENABLED=1
       - >-
         {{- if eq .Arch "arm64" }}CC=/usr/bin/aarch64-linux-gnu-gcc{{- end }}
+    ldflags:
+      - -w -s
+        -X github.com/prometheus/common/version.Version={{ .Version }}
+        -X github.com/prometheus/common/version.Revision={{ .Commit }}
+        -X github.com/prometheus/common/version.Branch={{ .Branch }}
+        -X github.com/prometheus/common/version.BuildDate={{ .Date }}
 dockers:
   - image_templates:
     - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-amd64"


### PR DESCRIPTION
With the official binary for version 0.18.0 :
```
$ ./postfix_exporter --version
2026/02/20 20:49:06 ERROR Invalid log level level="" error="unrecognized log level "
```
```
$ ./postfix_exporter --version --log.level=info --log.format=logfmt
0.18.0
```

The first commit fixes that by using flags from promslog (same names, same defaults).

The second commit changes the format of the output to be like the official exporters :

```
./postfix_exporter --version
postfix_exporter, version 0.18.0 (branch: , revision: 5c207efc5d4015fc446d908d91cb702699b29c9c)
  build user:
  build date:
  go version:       go1.25.7
  platform:         linux/amd64
  tags:             nokubernetes,nodocker
```

And also adds a build_info metric like many other exporters :

```
# HELP postfix_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which postfix_exporter was built, and the goos and goarch for the build.
# TYPE postfix_exporter_build_info gauge
postfix_exporter_build_info{branch="debian/sid",goarch="arm64",goos="linux",goversion="go1.24.4",revision="0.18.0-1~tonton13+1",tags="nokubernetes,nodocker",version="0.18.0"} 1

```

Please note that I did not test with goreleaser.