### PR TITLE
migrate to goreleaser dockers_v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,4 @@ jobs:
       additional-setup: |
         make libsystemd-dev
         make gcc-aarch64-linux-gnu
+      upload-image-sbom: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ before:
   hooks:
     - go mod download
 builds:
-  - id: default
+  - id: minimal
     env:
       - CGO_ENABLED=0
     flags:
@@ -21,6 +21,8 @@ builds:
         -X github.com/prometheus/common/version.Branch={{ .Branch }}
         -X github.com/prometheus/common/version.BuildDate={{ .Date }}
   - id: with-docker
+    goos:
+      - linux
     goarch:
       - amd64
       - arm64
@@ -68,47 +70,47 @@ builds:
         -X github.com/prometheus/common/version.Revision={{ .Commit }}
         -X github.com/prometheus/common/version.Branch={{ .Branch }}
         -X github.com/prometheus/common/version.BuildDate={{ .Date }}
-dockers:
-  - image_templates:
-    - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-amd64"
-    use: buildx
+dockers_v2:
+  - id: minimal
     ids:
-      - default
-    dockerfile: Dockerfile
+      - minimal
+    images:
+      - "ghcr.io/hsn723/{{.ProjectName}}"
+    tags:
+      - "{{ .Version }}-minimal"
+      - "{{ .Major }}.{{ .Minor }}-minimal"
     extra_files:
       - LICENSE
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - image_templates:
-    - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-arm64"
-    use: buildx
+    annotations:
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.base.name": "{{ .BaseImage }}"
+      "org.opencontainers.image.base.digest": "{{ .BaseImageDigest }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    sbom: true
+  - id: default
     ids:
-      - default
-    goarch: arm64
-    dockerfile: Dockerfile
+      - with-docker
+    images:
+      - "ghcr.io/hsn723/{{.ProjectName}}"
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Major }}.{{ .Minor }}"
     extra_files:
       - LICENSE
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-docker_manifests:
-  - name_template: "ghcr.io/hsn723/{{.ProjectName}}:latest"
-    image_templates:
-      - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-amd64"
-      - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-amd64"
-      - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/hsn723/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-amd64"
-      - "ghcr.io/hsn723/{{.ProjectName}}:{{ .Version }}-arm64"
+    annotations:
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.base.name": "{{ .BaseImage }}"
+      "org.opencontainers.image.base.digest": "{{ .BaseImageDigest }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    sbom: true
 archives:
   - id: default
     ids:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM scratch
+ARG TARGETPLATFORM
 LABEL org.opencontainers.image.source="https://github.com/hsn723/postfix_exporter" \
         org.opencontainers.image.authors="Hsn723" \
         org.opencontainers.image.title="postfix_exporter"
 EXPOSE 9154
-COPY postfix_exporter /
+COPY $TARGETPLATFORM/postfix_exporter /
 COPY LICENSE /
 ENTRYPOINT ["/postfix_exporter"]


### PR DESCRIPTION
Container image builds are migrated to the new goreleaser `dockers_v2` syntax which is more concise, and new image build definitions have been added. The "default" image is now renamed to minimal and contains the same minimal binary as before, whereas the new un-hyphened image contains a larger binary that includes docker support.

Closes #322 and #386 