### PR TITLE
Add Postscreen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These options can be used when starting the `postfix_exporter`
 | `--postfix.smtpd_service_label`   | User-defined service labels for the smtpd service.   | `smtpd`                  |
 | `--postfix.bounce_service_label`  | User-defined service labels for the bounce service.  | `bounce`                 |
 | `--postfix.virtual_service_label` | User-defined service labels for the virtual service. | `virtual`                |
+| `--postfix.postscreen_service_label` | User-defined service labels for the postscreen service. | `postscreen`         |
 | `--log.unsupported`      | Log all unsupported lines                            | `false`                           |
 | `--log.level`            | Logging level                                        | `"info"`                          |
 | `--log.format`           | Logging format                                       | `"logfmt"`                        |

--- a/exporter/postfix_exporter.go
+++ b/exporter/postfix_exporter.go
@@ -78,11 +78,12 @@ type PostfixExporter struct {
 
 	showq *showq.Showq
 
-	postscreenConnects  prometheus.Counter
-	postscreenPasses    *prometheus.CounterVec
-	postscreenDNSBLRank prometheus.Histogram
-	postscreenRejects   *prometheus.CounterVec
-	postscreenTests     *prometheus.CounterVec
+	postscreenConnects   prometheus.Counter
+	postscreenPasses     *prometheus.CounterVec
+	postscreenDNSBLRank  prometheus.Histogram
+	postscreenRejects    *prometheus.CounterVec
+	postscreenTests      *prometheus.CounterVec
+	postscreenAccessList *prometheus.CounterVec
 
 	bounceLabels     []string
 	cleanupLabels    []string
@@ -124,6 +125,7 @@ var (
 	postscreenDNSBLLine                 = regexp.MustCompile(`^DNSBL rank (\d+) for `)
 	postscreenRejectLine                = regexp.MustCompile(`^NOQUEUE: reject: RCPT from \S+: ([0-9]+) `)
 	postscreenTestLine                  = regexp.MustCompile(`^(PREGREET|NON-SMTP COMMAND|COMMAND PIPELINING|COMMAND TIME LIMIT|COMMAND COUNT LIMIT|COMMAND LENGTH LIMIT|BARE NEWLINE|HANGUP) `)
+	postscreenAccessListLine            = regexp.MustCompile(`^(ALLOWLISTED|WHITELISTED|DENYLISTED|BLACKLISTED) `)
 )
 
 func (e *PostfixExporter) collectFromPostfixLogLine(line, subprocess, level, remainder string) {
@@ -297,6 +299,12 @@ func (e *PostfixExporter) collectPostscreenLog(line, remainder, level string) {
 	} else if testMatches := postscreenTestLine.FindStringSubmatch(remainder); testMatches != nil {
 		test := strings.ReplaceAll(strings.ReplaceAll(testMatches[1], "-", "_"), " ", "_")
 		e.postscreenTests.WithLabelValues(test).Inc()
+	} else if accessListMatches := postscreenAccessListLine.FindStringSubmatch(remainder); accessListMatches != nil {
+		action := "allow"
+		if accessListMatches[1] == "DENYLISTED" || accessListMatches[1] == "BLACKLISTED" {
+			action = "deny"
+		}
+		e.postscreenAccessList.WithLabelValues(action).Inc()
 	} else {
 		e.addToUnsupportedLine(line, "postscreen", level)
 	}
@@ -690,6 +698,14 @@ func (e *PostfixExporter) init() {
 				ConstLabels: constLabels,
 			},
 			[]string{"test"})
+		e.postscreenAccessList = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   "postfix",
+				Name:        "postscreen_access_list_total",
+				Help:        "Total number of clients allow/deny-listed by postscreen (ALLOWLISTED/WHITELISTED/DENYLISTED/BLACKLISTED).",
+				ConstLabels: constLabels,
+			},
+			[]string{"action"})
 		e.postfixUp = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   "postfix",
@@ -771,6 +787,7 @@ func (e *PostfixExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.postscreenDNSBLRank.Desc()
 	e.postscreenRejects.Describe(ch)
 	e.postscreenTests.Describe(ch)
+	e.postscreenAccessList.Describe(ch)
 }
 
 func (e *PostfixExporter) StartMetricCollection(ctx context.Context) {
@@ -846,4 +863,5 @@ func (e *PostfixExporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- e.postscreenDNSBLRank
 	e.postscreenRejects.Collect(ch)
 	e.postscreenTests.Collect(ch)
+	e.postscreenAccessList.Collect(ch)
 }

--- a/exporter/postfix_exporter.go
+++ b/exporter/postfix_exporter.go
@@ -711,7 +711,7 @@ func (e *PostfixExporter) init() {
 		e.postscreenAccessList = prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace:   "postfix",
-				Name:        "postscreen_access_list_total",
+				Name:        "postscreen_access_list_matches_total",
 				Help:        "Total number of clients allow/deny-listed by postscreen (ALLOWLISTED/WHITELISTED/DENYLISTED/BLACKLISTED).",
 				ConstLabels: constLabels,
 			},

--- a/exporter/postfix_exporter.go
+++ b/exporter/postfix_exporter.go
@@ -78,14 +78,21 @@ type PostfixExporter struct {
 
 	showq *showq.Showq
 
-	bounceLabels  []string
-	cleanupLabels []string
-	smtpLabels    []string
-	smtpdLabels   []string
-	virtualLabels []string
-	qmgrLabels    []string
-	pipeLabels    []string
-	lmtpLabels    []string
+	postscreenConnects  prometheus.Counter
+	postscreenPasses    *prometheus.CounterVec
+	postscreenDNSBLRank prometheus.Histogram
+	postscreenRejects   *prometheus.CounterVec
+	postscreenTests     *prometheus.CounterVec
+
+	bounceLabels     []string
+	cleanupLabels    []string
+	smtpLabels       []string
+	smtpdLabels      []string
+	virtualLabels    []string
+	qmgrLabels       []string
+	pipeLabels       []string
+	lmtpLabels       []string
+	postscreenLabels []string
 
 	once sync.Once
 
@@ -113,6 +120,10 @@ var (
 	smtpdTLSLine                        = regexp.MustCompile(`^(\S+) TLS connection established from \S+: (\S+) with cipher (\S+) \((\d+)/(\d+) bits\)`)
 	opendkimSignatureAdded              = regexp.MustCompile(`^[\w\d]+: DKIM-Signature field added \(s=(\w+), d=(.*)\)$`)
 	bounceNonDeliveryLine               = regexp.MustCompile(`: sender non-delivery notification: `)
+	postscreenPassLine                  = regexp.MustCompile(`^PASS (NEW|OLD) `)
+	postscreenDNSBLLine                 = regexp.MustCompile(`^DNSBL rank (\d+) for `)
+	postscreenRejectLine                = regexp.MustCompile(`^NOQUEUE: reject: RCPT from \S+: ([0-9]+) `)
+	postscreenTestLine                  = regexp.MustCompile(`^(PREGREET|NON-SMTP COMMAND|COMMAND PIPELINING|COMMAND TIME LIMIT|COMMAND COUNT LIMIT|COMMAND LENGTH LIMIT|BARE NEWLINE|HANGUP) `)
 )
 
 func (e *PostfixExporter) collectFromPostfixLogLine(line, subprocess, level, remainder string) {
@@ -133,6 +144,8 @@ func (e *PostfixExporter) collectFromPostfixLogLine(line, subprocess, level, rem
 		e.collectBounceLog(line, remainder, level)
 	case slices.Contains(e.virtualLabels, subprocess):
 		e.collectVirtualLog(line, remainder, level)
+	case slices.Contains(e.postscreenLabels, subprocess):
+		e.collectPostscreenLog(line, remainder, level)
 	default:
 		e.addToUnsupportedLine(line, subprocess, level)
 	}
@@ -272,6 +285,23 @@ func (e *PostfixExporter) collectVirtualLog(line, remainder, level string) {
 	}
 }
 
+func (e *PostfixExporter) collectPostscreenLog(line, remainder, level string) {
+	if strings.HasPrefix(remainder, "CONNECT from ") {
+		e.postscreenConnects.Inc()
+	} else if passMatches := postscreenPassLine.FindStringSubmatch(remainder); passMatches != nil {
+		e.postscreenPasses.WithLabelValues(strings.ToLower(passMatches[1])).Inc()
+	} else if dnsblMatches := postscreenDNSBLLine.FindStringSubmatch(remainder); dnsblMatches != nil {
+		addToHistogram(e.postscreenDNSBLRank, dnsblMatches[1], "postscreen DNSBL rank")
+	} else if rejectMatches := postscreenRejectLine.FindStringSubmatch(remainder); rejectMatches != nil {
+		e.postscreenRejects.WithLabelValues(rejectMatches[1]).Inc()
+	} else if testMatches := postscreenTestLine.FindStringSubmatch(remainder); testMatches != nil {
+		test := strings.ReplaceAll(strings.ReplaceAll(testMatches[1], "-", "_"), " ", "_")
+		e.postscreenTests.WithLabelValues(test).Inc()
+	} else {
+		e.addToUnsupportedLine(line, "postscreen", level)
+	}
+}
+
 // CollectFromLogline collects metrict from a Postfix log line.
 func (e *PostfixExporter) CollectFromLogLine(line string) {
 	if line == "" {
@@ -327,14 +357,15 @@ func addToHistogramVec(h *prometheus.HistogramVec, value, fieldName string, labe
 }
 
 var (
-	defaultCleanupLabels = []string{"cleanup"}
-	defaultLmtpLabels    = []string{"lmtp"}
-	defaultPipeLabels    = []string{"pipe"}
-	defaultQmgrLabels    = []string{"qmgr"}
-	defaultSmtpLabels    = []string{"smtp"}
-	defaultSmtpdLabels   = []string{"smtpd"}
-	defaultBounceLabels  = []string{"bounce"}
-	defaultVirtualLabels = []string{"virtual"}
+	defaultCleanupLabels    = []string{"cleanup"}
+	defaultLmtpLabels       = []string{"lmtp"}
+	defaultPipeLabels       = []string{"pipe"}
+	defaultQmgrLabels       = []string{"qmgr"}
+	defaultSmtpLabels       = []string{"smtp"}
+	defaultSmtpdLabels      = []string{"smtpd"}
+	defaultBounceLabels     = []string{"bounce"}
+	defaultVirtualLabels    = []string{"virtual"}
+	defaultPostscreenLabels = []string{"postscreen"}
 )
 
 // WithCleanupLabels is a function to apply user-defined service labels to PostfixExporter.
@@ -390,6 +421,13 @@ func WithBounceLabels(labels []string) ServiceLabel {
 func WithVirtualLabels(labels []string) ServiceLabel {
 	return func(e *PostfixExporter) {
 		e.virtualLabels = labels
+	}
+}
+
+// WithPostscreenLabels is a function to apply user-defined service labels to PostfixExporter.
+func WithPostscreenLabels(labels []string) ServiceLabel {
+	return func(e *PostfixExporter) {
+		e.postscreenLabels = labels
 	}
 }
 
@@ -615,6 +653,43 @@ func (e *PostfixExporter) init() {
 			Help:        "Total number of mail delivered to a virtual mailbox.",
 			ConstLabels: constLabels,
 		})
+		e.postscreenConnects = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   "postfix",
+			Name:        "postscreen_connects_total",
+			Help:        "Total number of connections handled by postscreen.",
+			ConstLabels: constLabels,
+		})
+		e.postscreenPasses = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   "postfix",
+				Name:        "postscreen_passes_total",
+				Help:        "Total number of clients passed by postscreen, by allowlist status (new/old).",
+				ConstLabels: constLabels,
+			},
+			[]string{"type"})
+		e.postscreenDNSBLRank = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace:   "postfix",
+			Name:        "postscreen_dnsbl_rank",
+			Help:        "DNSBL rank assigned to clients by postscreen.",
+			Buckets:     []float64{0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 15},
+			ConstLabels: constLabels,
+		})
+		e.postscreenRejects = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   "postfix",
+				Name:        "postscreen_messages_rejected_total",
+				Help:        "Total number of NOQUEUE rejects issued by postscreen, by response code.",
+				ConstLabels: constLabels,
+			},
+			[]string{"code"})
+		e.postscreenTests = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   "postfix",
+				Name:        "postscreen_tests_failed_total",
+				Help:        "Total number of postscreen pre-greet/protocol test failures, by test name.",
+				ConstLabels: constLabels,
+			},
+			[]string{"test"})
 		e.postfixUp = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   "postfix",
@@ -639,6 +714,7 @@ func NewPostfixExporter(s *showq.Showq, logSrc logsource.LogSource, logUnsupport
 		smtpdLabels:         defaultSmtpdLabels,
 		bounceLabels:        defaultBounceLabels,
 		virtualLabels:       defaultVirtualLabels,
+		postscreenLabels:    defaultPostscreenLabels,
 		logUnsupportedLines: logUnsupportedLines,
 		showq:               s,
 		logSrc:              logSrc,
@@ -690,6 +766,11 @@ func (e *PostfixExporter) Describe(ch chan<- *prometheus.Desc) {
 	e.opendkimSignatureAdded.Describe(ch)
 	ch <- e.bounceNonDelivery.Desc()
 	ch <- e.virtualDelivered.Desc()
+	ch <- e.postscreenConnects.Desc()
+	e.postscreenPasses.Describe(ch)
+	ch <- e.postscreenDNSBLRank.Desc()
+	e.postscreenRejects.Describe(ch)
+	e.postscreenTests.Describe(ch)
 }
 
 func (e *PostfixExporter) StartMetricCollection(ctx context.Context) {
@@ -760,4 +841,9 @@ func (e *PostfixExporter) Collect(ch chan<- prometheus.Metric) {
 	e.opendkimSignatureAdded.Collect(ch)
 	ch <- e.bounceNonDelivery
 	ch <- e.virtualDelivered
+	ch <- e.postscreenConnects
+	e.postscreenPasses.Collect(ch)
+	ch <- e.postscreenDNSBLRank
+	e.postscreenRejects.Collect(ch)
+	e.postscreenTests.Collect(ch)
 }

--- a/exporter/postfix_exporter.go
+++ b/exporter/postfix_exporter.go
@@ -78,13 +78,14 @@ type PostfixExporter struct {
 
 	showq *showq.Showq
 
-	postscreenConnects   prometheus.Counter
-	postscreenPasses     *prometheus.CounterVec
-	postscreenDNSBLRank  prometheus.Histogram
-	postscreenRejects    *prometheus.CounterVec
-	postscreenTests      *prometheus.CounterVec
-	postscreenHangups    prometheus.Counter
-	postscreenAccessList *prometheus.CounterVec
+	postscreenConnects         prometheus.Counter
+	postscreenConnectsRejected *prometheus.CounterVec
+	postscreenPasses           *prometheus.CounterVec
+	postscreenDNSBLRank        prometheus.Histogram
+	postscreenRejects          *prometheus.CounterVec
+	postscreenTests            *prometheus.CounterVec
+	postscreenHangups          prometheus.Counter
+	postscreenAccessList       *prometheus.CounterVec
 
 	bounceLabels     []string
 	cleanupLabels    []string
@@ -124,6 +125,7 @@ var (
 	bounceNonDeliveryLine               = regexp.MustCompile(`: sender non-delivery notification: `)
 	postscreenPassLine                  = regexp.MustCompile(`^PASS (NEW|OLD) `)
 	postscreenDNSBLLine                 = regexp.MustCompile(`^DNSBL rank (\d+) for `)
+	postscreenConnectRejectLine         = regexp.MustCompile(`^NOQUEUE: reject: CONNECT from \S+: (.+)$`)
 	postscreenRejectLine                = regexp.MustCompile(`^NOQUEUE: reject: RCPT from \S+: ([0-9]+) `)
 	postscreenTestLine                  = regexp.MustCompile(`^(PREGREET|NON-SMTP COMMAND|COMMAND PIPELINING|COMMAND TIME LIMIT|COMMAND COUNT LIMIT|COMMAND LENGTH LIMIT|BARE NEWLINE) `)
 	postscreenHangupLine                = regexp.MustCompile(`^HANGUP `)
@@ -292,6 +294,8 @@ func (e *PostfixExporter) collectVirtualLog(line, remainder, level string) {
 func (e *PostfixExporter) collectPostscreenLog(line, remainder, level string) {
 	if strings.HasPrefix(remainder, "CONNECT from ") {
 		e.postscreenConnects.Inc()
+	} else if rejectMatches := postscreenConnectRejectLine.FindStringSubmatch(remainder); rejectMatches != nil {
+		e.postscreenConnectsRejected.WithLabelValues(rejectMatches[1]).Inc()
 	} else if passMatches := postscreenPassLine.FindStringSubmatch(remainder); passMatches != nil {
 		e.postscreenPasses.WithLabelValues(strings.ToLower(passMatches[1])).Inc()
 	} else if dnsblMatches := postscreenDNSBLLine.FindStringSubmatch(remainder); dnsblMatches != nil {
@@ -671,6 +675,14 @@ func (e *PostfixExporter) init() {
 			Help:        "Total number of connections handled by postscreen.",
 			ConstLabels: constLabels,
 		})
+		e.postscreenConnectsRejected = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   "postfix",
+				Name:        "postscreen_connects_rejected_total",
+				Help:        "Total number of connections rejected by postscreen, by reject reason.",
+				ConstLabels: constLabels,
+			},
+			[]string{"reason"})
 		e.postscreenPasses = prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace:   "postfix",
@@ -793,6 +805,7 @@ func (e *PostfixExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.bounceNonDelivery.Desc()
 	ch <- e.virtualDelivered.Desc()
 	ch <- e.postscreenConnects.Desc()
+	e.postscreenConnectsRejected.Describe(ch)
 	e.postscreenPasses.Describe(ch)
 	ch <- e.postscreenDNSBLRank.Desc()
 	e.postscreenRejects.Describe(ch)
@@ -870,6 +883,7 @@ func (e *PostfixExporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- e.bounceNonDelivery
 	ch <- e.virtualDelivered
 	ch <- e.postscreenConnects
+	e.postscreenConnectsRejected.Collect(ch)
 	e.postscreenPasses.Collect(ch)
 	ch <- e.postscreenDNSBLRank
 	e.postscreenRejects.Collect(ch)

--- a/exporter/postfix_exporter.go
+++ b/exporter/postfix_exporter.go
@@ -83,6 +83,7 @@ type PostfixExporter struct {
 	postscreenDNSBLRank  prometheus.Histogram
 	postscreenRejects    *prometheus.CounterVec
 	postscreenTests      *prometheus.CounterVec
+	postscreenHangups    prometheus.Counter
 	postscreenAccessList *prometheus.CounterVec
 
 	bounceLabels     []string
@@ -124,7 +125,8 @@ var (
 	postscreenPassLine                  = regexp.MustCompile(`^PASS (NEW|OLD) `)
 	postscreenDNSBLLine                 = regexp.MustCompile(`^DNSBL rank (\d+) for `)
 	postscreenRejectLine                = regexp.MustCompile(`^NOQUEUE: reject: RCPT from \S+: ([0-9]+) `)
-	postscreenTestLine                  = regexp.MustCompile(`^(PREGREET|NON-SMTP COMMAND|COMMAND PIPELINING|COMMAND TIME LIMIT|COMMAND COUNT LIMIT|COMMAND LENGTH LIMIT|BARE NEWLINE|HANGUP) `)
+	postscreenTestLine                  = regexp.MustCompile(`^(PREGREET|NON-SMTP COMMAND|COMMAND PIPELINING|COMMAND TIME LIMIT|COMMAND COUNT LIMIT|COMMAND LENGTH LIMIT|BARE NEWLINE) `)
+	postscreenHangupLine                = regexp.MustCompile(`^HANGUP `)
 	postscreenAccessListLine            = regexp.MustCompile(`^(ALLOWLISTED|WHITELISTED|DENYLISTED|BLACKLISTED) `)
 )
 
@@ -296,6 +298,8 @@ func (e *PostfixExporter) collectPostscreenLog(line, remainder, level string) {
 		addToHistogram(e.postscreenDNSBLRank, dnsblMatches[1], "postscreen DNSBL rank")
 	} else if rejectMatches := postscreenRejectLine.FindStringSubmatch(remainder); rejectMatches != nil {
 		e.postscreenRejects.WithLabelValues(rejectMatches[1]).Inc()
+	} else if postscreenHangupLine.MatchString(remainder) {
+		e.postscreenHangups.Inc()
 	} else if testMatches := postscreenTestLine.FindStringSubmatch(remainder); testMatches != nil {
 		test := strings.ReplaceAll(strings.ReplaceAll(testMatches[1], "-", "_"), " ", "_")
 		e.postscreenTests.WithLabelValues(test).Inc()
@@ -698,6 +702,12 @@ func (e *PostfixExporter) init() {
 				ConstLabels: constLabels,
 			},
 			[]string{"test"})
+		e.postscreenHangups = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   "postfix",
+			Name:        "postscreen_hangups_total",
+			Help:        "Total client disconnects reported by postscreen while testing.",
+			ConstLabels: constLabels,
+		})
 		e.postscreenAccessList = prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace:   "postfix",
@@ -787,6 +797,7 @@ func (e *PostfixExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.postscreenDNSBLRank.Desc()
 	e.postscreenRejects.Describe(ch)
 	e.postscreenTests.Describe(ch)
+	ch <- e.postscreenHangups.Desc()
 	e.postscreenAccessList.Describe(ch)
 }
 
@@ -863,5 +874,6 @@ func (e *PostfixExporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- e.postscreenDNSBLRank
 	e.postscreenRejects.Collect(ch)
 	e.postscreenTests.Collect(ch)
+	ch <- e.postscreenHangups
 	e.postscreenAccessList.Collect(ch)
 }

--- a/exporter/postfix_exporter_test.go
+++ b/exporter/postfix_exporter_test.go
@@ -36,6 +36,8 @@ type args struct {
 	postscreenTests        int
 	postscreenHangups      int
 	postscreenAccessList   int
+	psdnsblRankSampleCount uint64
+	psdnsblRankSampleSum   float64
 }
 
 type testCase struct {
@@ -67,6 +69,7 @@ func testPostfixExporter_CollectFromLogline(t *testing.T, tt testCase) {
 	assertCounterEquals(t, e.postscreenTests, tt.args.postscreenTests, "Wrong number of postscreen test failures")
 	assertCounterEquals(t, e.postscreenHangups, tt.args.postscreenHangups, "Wrong number of postscreen hangups")
 	assertCounterEquals(t, e.postscreenAccessList, tt.args.postscreenAccessList, "Wrong number of postscreen access list events")
+	assertHistogramEquals(t, e.postscreenDNSBLRank, tt.args.psdnsblRankSampleCount, tt.args.psdnsblRankSampleSum, "Wrong DNSBL rank histogram")
 	assertCounterVecMetricsEquals(t, e.unsupportedLogEntries, tt.args.unsupportedLogEntries, "Wrong number of unsupportedLogEntries")
 }
 
@@ -225,6 +228,8 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 				postscreenRejects:  1,
 				postscreenTests:    1,
 				postscreenHangups:  1,
+				psdnsblRankSampleCount: 1,
+				psdnsblRankSampleSum:   3,
 			},
 		},
 		{
@@ -383,4 +388,17 @@ func assertCounterVecMetricsEquals(t *testing.T, counter *prometheus.CounterVec,
 		res = append(res, cm)
 	}
 	assert.ElementsMatch(t, expected, res, message)
+}
+
+func assertHistogramEquals(t *testing.T, hist prometheus.Histogram, expectedCount uint64, expectedSum float64, message string) {
+	t.Helper()
+
+	metric := &io_prometheus_client.Metric{}
+	err := hist.Write(metric)
+	assert.NoError(t, err)
+
+	if assert.NotNil(t, metric.Histogram) {
+		assert.Equal(t, expectedCount, metric.Histogram.GetSampleCount(), message)
+		assert.InDelta(t, expectedSum, metric.Histogram.GetSampleSum(), 0.0001, message)
+	}
 }

--- a/exporter/postfix_exporter_test.go
+++ b/exporter/postfix_exporter_test.go
@@ -34,6 +34,7 @@ type args struct {
 	postscreenPasses       int
 	postscreenRejects      int
 	postscreenTests        int
+	postscreenAccessList   int
 }
 
 type testCase struct {
@@ -63,6 +64,7 @@ func testPostfixExporter_CollectFromLogline(t *testing.T, tt testCase) {
 	assertCounterEquals(t, e.postscreenPasses, tt.args.postscreenPasses, "Wrong number of postscreen passes")
 	assertCounterEquals(t, e.postscreenRejects, tt.args.postscreenRejects, "Wrong number of postscreen rejects")
 	assertCounterEquals(t, e.postscreenTests, tt.args.postscreenTests, "Wrong number of postscreen test failures")
+	assertCounterEquals(t, e.postscreenAccessList, tt.args.postscreenAccessList, "Wrong number of postscreen access list events")
 	assertCounterVecMetricsEquals(t, e.unsupportedLogEntries, tt.args.unsupportedLogEntries, "Wrong number of unsupportedLogEntries")
 }
 
@@ -220,6 +222,18 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 				postscreenPasses:   2,
 				postscreenRejects:  1,
 				postscreenTests:    2,
+			},
+		},
+		{
+			name: "Testing postscreen allow/deny list",
+			args: args{
+				line: []string{
+					"Feb 24 16:18:40 letterman postfix/postscreen[3508454]: ALLOWLISTED [69.171.232.146]:61236",
+					"Feb 24 16:18:40 letterman postfix/postscreen[3508454]: WHITELISTED [69.171.232.147]:61236",
+					"Feb 24 16:18:40 letterman postfix/postscreen[3508454]: DENYLISTED [1.2.3.4]:5678",
+					"Feb 24 16:18:40 letterman postfix/postscreen[3508454]: BLACKLISTED [1.2.3.5]:5678",
+				},
+				postscreenAccessList: 4,
 			},
 		},
 		{

--- a/exporter/postfix_exporter_test.go
+++ b/exporter/postfix_exporter_test.go
@@ -34,6 +34,7 @@ type args struct {
 	postscreenPasses       int
 	postscreenRejects      int
 	postscreenTests        int
+	postscreenHangups      int
 	postscreenAccessList   int
 }
 
@@ -64,6 +65,7 @@ func testPostfixExporter_CollectFromLogline(t *testing.T, tt testCase) {
 	assertCounterEquals(t, e.postscreenPasses, tt.args.postscreenPasses, "Wrong number of postscreen passes")
 	assertCounterEquals(t, e.postscreenRejects, tt.args.postscreenRejects, "Wrong number of postscreen rejects")
 	assertCounterEquals(t, e.postscreenTests, tt.args.postscreenTests, "Wrong number of postscreen test failures")
+	assertCounterEquals(t, e.postscreenHangups, tt.args.postscreenHangups, "Wrong number of postscreen hangups")
 	assertCounterEquals(t, e.postscreenAccessList, tt.args.postscreenAccessList, "Wrong number of postscreen access list events")
 	assertCounterVecMetricsEquals(t, e.unsupportedLogEntries, tt.args.unsupportedLogEntries, "Wrong number of unsupportedLogEntries")
 }
@@ -221,7 +223,8 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 				postscreenConnects: 1,
 				postscreenPasses:   2,
 				postscreenRejects:  1,
-				postscreenTests:    2,
+				postscreenTests:    1,
+				postscreenHangups:  1,
 			},
 		},
 		{

--- a/exporter/postfix_exporter_test.go
+++ b/exporter/postfix_exporter_test.go
@@ -18,26 +18,28 @@ func stringPtr(s string) *string {
 }
 
 type args struct {
-	line                   []string
-	unsupportedLogEntries  []testCounterMetric
-	removedCount           int
-	expiredCount           int
-	saslFailedCount        int
-	outgoingTLS            int
-	smtpdMessagesProcessed int
-	smtpMessagesProcessed  int
-	smtpDeferred           int
-	smtpBounced            int
-	bounceNonDelivery      int
-	virtualDelivered       int
-	postscreenConnects     int
-	postscreenPasses       int
-	postscreenRejects      int
-	postscreenTests        int
-	postscreenHangups      int
-	postscreenAccessList   int
-	psdnsblRankSampleCount uint64
-	psdnsblRankSampleSum   float64
+	line                       []string
+	unsupportedLogEntries      []testCounterMetric
+	removedCount               int
+	expiredCount               int
+	saslFailedCount            int
+	outgoingTLS                int
+	smtpdMessagesProcessed     int
+	smtpMessagesProcessed      int
+	smtpDeferred               int
+	smtpBounced                int
+	bounceNonDelivery          int
+	virtualDelivered           int
+	postscreenConnects         int
+	postscreenConnectsRejected int
+	postscreenConnectRejects   []testCounterMetric
+	postscreenPasses           int
+	postscreenRejects          int
+	postscreenTests            int
+	postscreenHangups          int
+	postscreenAccessList       int
+	psdnsblRankSampleCount     uint64
+	psdnsblRankSampleSum       float64
 }
 
 type testCase struct {
@@ -64,6 +66,8 @@ func testPostfixExporter_CollectFromLogline(t *testing.T, tt testCase) {
 	assertCounterEquals(t, e.bounceNonDelivery, tt.args.bounceNonDelivery, "Wrong number of non delivery notifications")
 	assertCounterEquals(t, e.virtualDelivered, tt.args.virtualDelivered, "Wrong number of delivered mails")
 	assertCounterEquals(t, e.postscreenConnects, tt.args.postscreenConnects, "Wrong number of postscreen connects")
+	assertCounterEquals(t, e.postscreenConnectsRejected, tt.args.postscreenConnectsRejected, "Wrong number of postscreen connect rejects")
+	assertCounterVecMetricsEquals(t, e.postscreenConnectsRejected, tt.args.postscreenConnectRejects, "Wrong postscreen connect reject reasons")
 	assertCounterEquals(t, e.postscreenPasses, tt.args.postscreenPasses, "Wrong number of postscreen passes")
 	assertCounterEquals(t, e.postscreenRejects, tt.args.postscreenRejects, "Wrong number of postscreen rejects")
 	assertCounterEquals(t, e.postscreenTests, tt.args.postscreenTests, "Wrong number of postscreen test failures")
@@ -216,6 +220,9 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 			args: args{
 				line: []string{
 					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: CONNECT from [1.2.3.4]:5678 to [5.6.7.8]:25",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: NOQUEUE: reject: CONNECT from [1.2.3.4]:5678: too many connections",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: NOQUEUE: reject: CONNECT from [1.2.3.4]:5678: all screening ports busy",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: NOQUEUE: reject: CONNECT from [1.2.3.4]:5678: all server ports busy",
 					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: PASS NEW [1.2.3.4]:5678",
 					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: PASS OLD [9.8.7.6]:1234",
 					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: DNSBL rank 3 for [1.2.3.4]:5678",
@@ -223,11 +230,17 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: HANGUP after 2.5 from [1.2.3.4]:5678 in tests after SMTP handshake",
 					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: NOQUEUE: reject: RCPT from [1.2.3.4]:5678: 550 5.7.1 Service unavailable; client [1.2.3.4] blocked using zen.spamhaus.org; from=<a@b.com> to=<c@d.com> proto=ESMTP helo=<x>",
 				},
-				postscreenConnects: 1,
-				postscreenPasses:   2,
-				postscreenRejects:  1,
-				postscreenTests:    1,
-				postscreenHangups:  1,
+				postscreenConnects:         1,
+				postscreenConnectsRejected: 3,
+				postscreenConnectRejects: []testCounterMetric{
+					{Label: []*io_prometheus_client.LabelPair{{Name: stringPtr("reason"), Value: stringPtr("too many connections")}}, CounterValue: 1},
+					{Label: []*io_prometheus_client.LabelPair{{Name: stringPtr("reason"), Value: stringPtr("all screening ports busy")}}, CounterValue: 1},
+					{Label: []*io_prometheus_client.LabelPair{{Name: stringPtr("reason"), Value: stringPtr("all server ports busy")}}, CounterValue: 1},
+				},
+				postscreenPasses:       2,
+				postscreenRejects:      1,
+				postscreenTests:        1,
+				postscreenHangups:      1,
 				psdnsblRankSampleCount: 1,
 				psdnsblRankSampleSum:   3,
 			},

--- a/exporter/postfix_exporter_test.go
+++ b/exporter/postfix_exporter_test.go
@@ -30,6 +30,10 @@ type args struct {
 	smtpBounced            int
 	bounceNonDelivery      int
 	virtualDelivered       int
+	postscreenConnects     int
+	postscreenPasses       int
+	postscreenRejects      int
+	postscreenTests        int
 }
 
 type testCase struct {
@@ -55,6 +59,10 @@ func testPostfixExporter_CollectFromLogline(t *testing.T, tt testCase) {
 	assertCounterEquals(t, e.smtpBouncedDSN, tt.args.smtpBounced, "Wrong number of smtp bounced")
 	assertCounterEquals(t, e.bounceNonDelivery, tt.args.bounceNonDelivery, "Wrong number of non delivery notifications")
 	assertCounterEquals(t, e.virtualDelivered, tt.args.virtualDelivered, "Wrong number of delivered mails")
+	assertCounterEquals(t, e.postscreenConnects, tt.args.postscreenConnects, "Wrong number of postscreen connects")
+	assertCounterEquals(t, e.postscreenPasses, tt.args.postscreenPasses, "Wrong number of postscreen passes")
+	assertCounterEquals(t, e.postscreenRejects, tt.args.postscreenRejects, "Wrong number of postscreen rejects")
+	assertCounterEquals(t, e.postscreenTests, tt.args.postscreenTests, "Wrong number of postscreen test failures")
 	assertCounterVecMetricsEquals(t, e.unsupportedLogEntries, tt.args.unsupportedLogEntries, "Wrong number of unsupportedLogEntries")
 }
 
@@ -194,6 +202,24 @@ func TestPostfixExporter_CollectFromLogline(t *testing.T) {
 					"Apr  7 15:35:20 123-mail postfix/virtual[20235]: 199041033BE: to=<me@domain.fr>, relay=virtual, delay=0.08, delays=0.08/0/0/0, dsn=2.0.0, status=sent (delivered to maildir)",
 				},
 				virtualDelivered: 1,
+			},
+		},
+		{
+			name: "Testing postscreen stats",
+			args: args{
+				line: []string{
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: CONNECT from [1.2.3.4]:5678 to [5.6.7.8]:25",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: PASS NEW [1.2.3.4]:5678",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: PASS OLD [9.8.7.6]:1234",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: DNSBL rank 3 for [1.2.3.4]:5678",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: PREGREET 14 after 0.18 from [1.2.3.4]:5678: EHLO [74.207.242.122]",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: HANGUP after 2.5 from [1.2.3.4]:5678 in tests after SMTP handshake",
+					"Feb 24 16:18:40 letterman postfix/postscreen[1234]: NOQUEUE: reject: RCPT from [1.2.3.4]:5678: 550 5.7.1 Service unavailable; client [1.2.3.4] blocked using zen.spamhaus.org; from=<a@b.com> to=<c@d.com> proto=ESMTP helo=<x>",
+				},
+				postscreenConnects: 1,
+				postscreenPasses:   2,
+				postscreenRejects:  1,
+				postscreenTests:    2,
 			},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	_ "embed"
@@ -16,11 +16,11 @@ import (
 	"github.com/hsn723/postfix_exporter/logsource"
 	"github.com/hsn723/postfix_exporter/showq"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
-	"github.com/prometheus/common/version"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/promslog/flag"
+	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
 )
@@ -39,14 +39,15 @@ var (
 
 	logConfig *promslog.Config
 
-	cleanupLabels []string
-	lmtpLabels    []string
-	pipeLabels    []string
-	qmgrLabels    []string
-	smtpLabels    []string
-	smtpdLabels   []string
-	bounceLabels  []string
-	virtualLabels []string
+	cleanupLabels    []string
+	lmtpLabels       []string
+	pipeLabels       []string
+	qmgrLabels       []string
+	smtpLabels       []string
+	smtpdLabels      []string
+	bounceLabels     []string
+	virtualLabels    []string
+	postscreenLabels []string
 
 	useWatchdog bool
 )
@@ -86,6 +87,7 @@ func initializeExporters(logSrcs []logsource.LogSourceCloser) []*exporter.Postfi
 			exporter.WithSmtpdLabels(smtpdLabels),
 			exporter.WithBounceLabels(bounceLabels),
 			exporter.WithVirtualLabels(virtualLabels),
+			exporter.WithPostscreenLabels(postscreenLabels),
 		)
 		prometheus.MustRegister(exporter)
 		exporters = append(exporters, exporter)
@@ -168,6 +170,7 @@ func init() {
 	app.Flag("postfix.smtpd_service_label", "User-defined service labels for the smtpd service.").Default("smtpd").StringsVar(&smtpdLabels)
 	app.Flag("postfix.bounce_service_label", "User-defined service labels for the bounce service.").Default("bounce").StringsVar(&bounceLabels)
 	app.Flag("postfix.virtual_service_label", "User-defined service labels for the virtual service.").Default("virtual").StringsVar(&virtualLabels)
+	app.Flag("postfix.postscreen_service_label", "User-defined service labels for the postscreen service.").Default("postscreen").StringsVar(&postscreenLabels)
 
 	app.HelpFlag.Short('h')
 


### PR DESCRIPTION
This pull request adds support for postscreen (test failures, DNSBL rank info, access lists, hangups) metrics. I've tested on my server and the stats appear to be correct.